### PR TITLE
Update manifest to use new Azure Pipelines category

### DIFF
--- a/Extension/vss-extension.json
+++ b/Extension/vss-extension.json
@@ -6,7 +6,7 @@
   "publisher": "chrisgardner",
   "description": "Tasks for interacting with Deployment Groups",
   "categories": [
-    "Build and release"
+    "Azure Pipelines"
   ],
   "targets": [
     {


### PR DESCRIPTION
### What problem does this PR address?
Manifest contains Build and Release category but it should be Azure Pipelines.
  
### Is there a related Issue?
No
  
### Have you...
- Added a new release line entry in to the extensions readme.md file (the list is usually found at the end of the file) that 
  - increments the minor version number e.g. 1.2 to 1.3
  - lists the Issue/PR number related to the change
  - provides a brief single line comment as to the change made
  - if the change adds new parameters update the appropriate documentation
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
