### PR TITLE
Add credential to arguments passed to Invoke-Command so it actually works

### DIFF
--- a/Extension/AddMachine/AddMachine.ps1
+++ b/Extension/AddMachine/AddMachine.ps1
@@ -14,6 +14,7 @@ $Credential = New-Object System.Management.Automation.PSCredential ($AdminUserNa
 
 $InvokeCommandSplat = @{
     ComputerName = $ComputerName
+    Credential = $Credential
     ArgumentList = @(
         $AgentPath
         $DeploymentGroupName


### PR DESCRIPTION
### What problem does this PR address?
Credentials weren't actually being added to the hashtable for splatting in to Invoke-Command so it wasn't actually using them to login to the remote box.
  
### Is there a related Issue?
No
  
### Have you...
- Added a new release line entry in to the extensions readme.md file (the list is usually found at the end of the file) that 
  - increments the minor version number e.g. 1.2 to 1.3
  - lists the Issue/PR number related to the change
  - provides a brief single line comment as to the change made
  - if the change adds new parameters update the appropriate documentation
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
