### PR TITLE
Add REST api checks to ensure agent is online before ending task

### DIFF
--- a/Extension/readme.md
+++ b/Extension/readme.md
@@ -14,3 +14,5 @@ A task to add one or more machines to a Deployment Group. It accepts the followi
 * Password: Password of the local admin account.
 * Protocol: Protocol to use for connecting with the machines. Defaults to HTTP.
 * Test Certificate: Indicates whether the certificate on the HTTPS endpoint is a test certificate, such as self signed.
+
+*Note*: The task requires access to the build/release agent's OAuth token to ensure that the newly deployed Deployment Group agent has successfully joined the target group and is showing as online.


### PR DESCRIPTION
### What problem does this PR address?
The newly deployed agent was taking a little while to correctly connect and show as online. If attempting to make use of the agent too quickly after it was being registered then it was showing as not available.

### Is there a related Issue?
No
  
### Have you...
- Added a new release line entry in to the extensions readme.md file (the list is usually found at the end of the file) that 
  - increments the minor version number e.g. 1.2 to 1.3
  - lists the Issue/PR number related to the change
  - provides a brief single line comment as to the change made
  - if the change adds new parameters update the appropriate documentation
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
