### PR TITLE
Allow running agent as specific user

### DIFF
--- a/Extension/AddMachine/AddMachine.ps1
+++ b/Extension/AddMachine/AddMachine.ps1
@@ -93,14 +93,14 @@ $InvokeCommandScript = {
 
     $ConfigSettings = @(
         '--deploymentgroup'
-        "--deploymentgroupname '$DeploymentGroupName'"
-        "--agent '$env:COMPUTERNAME'"
+        "--deploymentgroupname $DeploymentGroupName"
+        "--agent $env:COMPUTERNAME"
         "--runasservice"
         "--work '_work'"
-        "--url '$Url'"
-        "--projectname '$Project'"
+        "--url $Url"
+        "--projectname $Project"
         "--auth PAT"
-        "--token '$AccessToken'"
+        "--token $AccessToken"
     )
 
     if ([bool]::Parse($Replace)) {

--- a/Extension/AddMachine/task.json
+++ b/Extension/AddMachine/task.json
@@ -101,6 +101,22 @@
       "visibleRule": "Protocol = Https",
       "required": false,
       "helpMarkDown": "Select the option to skip validating the authenticity of the machine's certificate by a trusted certification authority. The parameter is required for the WinRM HTTPS protocol."
+    },
+    {
+      "name": "RunAsUserName",
+      "type": "string",
+      "label": "Run As Login",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Username to run the agent service as, if required. <br> Eg: Format: Domain\\Admin User, Admin User@Domain, .\\Admin User"
+    },
+    {
+      "name": "RunAsPassword",
+      "type": "string",
+      "label": "Run As Password",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Password for user account to run the agent service as, if required. <br>It can accept variable defined in build or release pipelines as '$(passwordVariable)'. <br>You may mark variable type as 'secret' to secure it."
     }
   ],
   "instanceNameFormat": "Add Machine(s) to Deployment Group",


### PR DESCRIPTION
### What problem does this PR address?
Agent currently runs as local system, however some cases will call for the agent to run as a specific user account.
  
### Is there a related Issue?
No
  
### Have you...
- Added a new release line entry in to the extensions readme.md file (the list is usually found at the end of the file) that 
  - increments the minor version number e.g. 1.2 to 1.3
  - lists the Issue/PR number related to the change
  - provides a brief single line comment as to the change made
  - if the change adds new parameters update the appropriate documentation
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
