### PR TITLE
Check if service already exists and then exit early if it does

### DIFF
--- a/Extension/AddMachine/AddMachine.ps1
+++ b/Extension/AddMachine/AddMachine.ps1
@@ -52,6 +52,10 @@ $InvokeCommandScript = {
     )
     $ErrorActionPreference = "Stop"
 
+    if (Get-Service -Name VSTS*$Env:ComputerName) {
+        return $Env:ComputerName
+    }
+
     Write-Verbose -Message "Creating agent folder in $AgentPath"
     If (-not (Test-Path $AgentPath)) {
         $null = New-Item -Path $AgentPath -ItemType Directory
@@ -96,7 +100,7 @@ $InvokeCommandScript = {
         "--deploymentgroupname $DeploymentGroupName"
         "--agent $env:COMPUTERNAME"
         "--runasservice"
-        "--work '_work'"
+        "--work _work"
         "--url $Url"
         "--projectname $Project"
         "--auth PAT"


### PR DESCRIPTION
### What problem does this PR address?
Task will attempt to install agent each time but will fail if it already exists. Should check if it already does exist and exit early if it does.
  
### Is there a related Issue?
No
  
### Have you...
- Added a new release line entry in to the extensions readme.md file (the list is usually found at the end of the file) that 
  - increments the minor version number e.g. 1.2 to 1.3
  - lists the Issue/PR number related to the change
  - provides a brief single line comment as to the change made
  - if the change adds new parameters update the appropriate documentation
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
