### PR TITLE
Add agent path input to allow changing. -Fixes #14

### DIFF
--- a/Extension/AddMachine/task.json
+++ b/Extension/AddMachine/task.json
@@ -50,6 +50,14 @@
       "helpMarkDown": "Project containing the deployment group. Defaults to the current project containing this task."
     },
     {
+      "name": "AgentPath",
+      "type": "string",
+      "label": "Agent Path",
+      "defaultValue": "C:\\azagent",
+      "required": false,
+      "helpMarkDown": "Path to provision the deployment group agent in. Defaults to C:\\azagent"
+    },
+    {
       "name": "ComputerName",
       "type": "multiLine",
       "label": "Machines",


### PR DESCRIPTION
### What problem does this PR address?
Agent path for creating the new deployment agent was not configurable.
  
### Is there a related Issue?
#14
  
### Have you...
- Added a new release line entry in to the extensions readme.md file (the list is usually found at the end of the file) that 
  - increments the minor version number e.g. 1.2 to 1.3
  - lists the Issue/PR number related to the change
  - provides a brief single line comment as to the change made
  - if the change adds new parameters update the appropriate documentation
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
