### PR TITLE
Check the agent status using jobs to allow parrallel checking

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ trigger:
 
 variables:
   major: 0
-  minor: 1
+  minor: 2
   ExtensionId: CLG-DeploymentGroups
   PackageId: chrisgardner
 


### PR DESCRIPTION
### What problem does this PR address?
Fixes an issue where there are multiple agent names provided and the task doesn't exit cleanly.
  
### Is there a related Issue?
No